### PR TITLE
E.G.G. #5-3 add-iam-policy-binding を短縮化

### DIFF
--- a/egg5-3/tutorial.md
+++ b/egg5-3/tutorial.md
@@ -259,84 +259,26 @@ gcloud compute firewall-rules create allow-datastream \
 SERVICE_ACCOUNT=$(gcloud iam service-accounts list --filter="displayName:Compute Engine default service account" --format="value(email)")
 ```
 
-Cloud SQL Client の権限を付与します。これは Cloud SQL Auth Proxy からのアクセスに利用します。
+次の Role を Service Account に付与します。
 
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/cloudsql.client
+ * Cloud SQL Client: Cloud SQL Auth Proxy からのアクセス
+ * Logging Writer: Compute Engine のスタートアップ スクリプトで利用
+ * Dataflow Worker: Dataflow Job の実行に利用
+ * Datastream Viewer: Dataflow Job での Datastream Schema 取得に利用
+ * Pub/Sub Editor: Dataflow Job の実行時の Pub/Sub Subscription Pull で利用
+ * Pub/Sub Subscriber: Dataflow Job の実行時の Pub/Sub Subscribe で利用
+ * Pub/Sub Viewer: Dataflow Job の実行時の Pub/Sub Topic と Subscription の取得で利用
+ * Storage Object Viewer: Dataflow Job の実行時の Storage Object List で利用
+ * BigQuery DataEditor: Dataflow Job の実行時の BigQuery テーブルへの書き込みに利用
+ * BigQuery JobUser: Dataflow Job の実行時の BigQuery Job 実行に利用
+
 ```
-
-Logging Writer の権限を付与します。これは Compute Engine のスタートアップ スクリプトで利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/logging.logWriter
-```
-
-Dataflow Worker の権限を付与します。これは Dataflow Job の実行に利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/dataflow.worker
-```
-
-Datastream Viewer の権限を付与します。これは Dataflow Job での Datastream Schema 取得に利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/datastream.viewer
-```
-
-Pub/Sub Editor の権限を付与します。これは Dataflow Job の実行時の Pub/Sub Subscription Pull で利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/pubsub.editor
-```
-
-Pub/Sub Subscriber の権限を付与します。これは Dataflow Job の実行時の Pub/Sub Subscribe で利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/pubsub.subscriber
-```
-
-Pub/Sub Viewer の権限を付与します。これは Dataflow Job の実行時の Pub/Sub Topic と Subscription の取得で利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/pubsub.viewer
-```
-
-Storage Object Viewer の権限を付与します。これは Dataflow Job の実行時の Storage Object List で利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/storage.objectViewer
-```
-
-BigQuery DataEditor の権限を付与します。これは Dataflow Job の実行時の BigQuery テーブルへの書き込みに利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/bigquery.dataEditor
-```
-
-BigQuery JobUser の権限を付与します。これは Dataflow Job の実行時の BigQuery Job 実行に利用します。
-
-```bash
-gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
-    --member serviceAccount:${SERVICE_ACCOUNT} \
-    --role roles/bigquery.jobUser
+for role in cloudsql.client logging.logWriter dataflow.worker datastream.viewer pubsub.editor pubsub.subscriber pubsub.viewer storage.objectViewer bigquery.dataEditor bigquery.jobUser
+do
+  gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
+      --member serviceAccount:${SERVICE_ACCOUNT} \
+      --role roles/${role}
+done
 ```
 
 ## [演習] 5-2. Datastream リソースの作成 (ネットワーク設定)

--- a/egg5-3/tutorial.md
+++ b/egg5-3/tutorial.md
@@ -75,10 +75,13 @@ Private IP を持つ場合、[プライベートサービスアクセス](https:
 
 ![プライベートサービスアクセス](https://github.com/google-cloud-japan/egg-training-materials/blob/main/egg5-3/images/2-1.png?raw=true)
 
-Compute 系の API を使うため、API を有効化します。
+本ハンズオンで利用するサービスの API 群を有効化します。
 
 ```bash
 gcloud services enable compute.googleapis.com
+gcloud services enable servicenetworking.googleapis.com
+gcloud services enable sqladmin.googleapis.com
+gcloud services enable dataflow.googleapis.com
 ```
 
 Cloud SQL の Private IP が利用する VPC ネットワークを作成します。
@@ -107,12 +110,6 @@ gcloud compute addresses create google-managed-services-cloudsql --global \
     --network=projects/${GOOGLE_CLOUD_PROJECT}/global/networks/cloudsql
 ```
 
-VPC Peering を実行するために、Service Networking の API を有効化します。
-
-```bash
-gcloud services enable servicenetworking.googleapis.com
-```
-
 プライベート接続を作成します。
 
 ```bash
@@ -129,12 +126,6 @@ gcloud services vpc-peerings connect \
 プライベート接続の作成には数分かかります。
 
 #### **Cloud SQL for MySQL インスタンスの作成**
-
-Cloud SQL の API を有効化します。
-
-```bash
-gcloud services enable sqladmin.googleapis.com
-```
 
 それでは Cloud SQL for MySQL インスタンスを gcloud コマンドで作成します。
 
@@ -640,12 +631,6 @@ Datastream でストリームしたデータの最終宛先であるデータセ
 BigQuery へのデータの連携は Dataflow Job で行います。
 
 ![システム構成8](https://github.com/google-cloud-japan/egg-training-materials/blob/main/egg5-3/images/goal8.png?raw=true)
-
-Dataflow の API を有効化します。
-
-```bash
-gcloud services enable dataflow.googleapis.com
-```
 
 Dataflow VM 間での通信を許可するファイアウォール ルールを作成します。このファイアウォール ルールは Dataflow Shuffle の通信に使います。
 


### PR DESCRIPTION
* [add-iam-policy-binding を短縮化](https://github.com/google-cloud-japan/egg-training-materials/commit/0f8d5db58a553d2b4ed0bc73d17623aedf4bfa30)
* [gcloud services enable を一箇所にまとめる](https://github.com/google-cloud-japan/egg-training-materials/commit/726ac8a41b231418a4614e0ed8915c47789c7880)